### PR TITLE
fix(table): 修复表格分页计算问题

### DIFF
--- a/src/components/Table/src/hooks/useDataSource.ts
+++ b/src/components/Table/src/hooks/useDataSource.ts
@@ -74,10 +74,9 @@ export function useDataSource(
 
       // 如果数据异常，需获取正确的页码再次执行
       if (resultTotal) {
-        const currentTotalPage = Math.ceil(resultTotal / pageSize);
-        if (page > currentTotalPage) {
+        if (page > resultTotal) {
           setPagination({
-            [pageField]: currentTotalPage,
+            [pageField]: resultTotal,
           });
           fetch(opt);
         }


### PR DESCRIPTION
组件-基础表格中，点击6页以后的页数会自动跳回6页。这里拿到的是总页数，不需要重新计算页数。