### PR TITLE
fix: constantRouter重复添加和addRoute优化

### DIFF
--- a/src/router/generator-routers.ts
+++ b/src/router/generator-routers.ts
@@ -1,7 +1,5 @@
 import { adminMenus } from '@/api/system/menu';
 import { constantRouterIcon } from './router-icons';
-import router from '@/router/index';
-import { constantRouter } from '@/router/index';
 import { RouteRecordRaw } from 'vue-router';
 import { Layout, ParentLayout } from '@/router/constant';
 import type { AppRouteRecordRaw } from '@/router/types';
@@ -61,11 +59,8 @@ export const generatorDynamicRouter = (): Promise<RouteRecordRaw[]> => {
       .then((result) => {
         const routeList = routerGenerator(result);
         asyncImportRoute(routeList);
-        const asyncRoutesList = [...routeList, ...constantRouter];
-        asyncRoutesList.forEach((item) => {
-          router.addRoute(item);
-        });
-        resolve(asyncRoutesList);
+
+        resolve(routeList);
       })
       .catch((err) => {
         reject(err);

--- a/src/store/modules/asyncRoute.ts
+++ b/src/store/modules/asyncRoute.ts
@@ -107,7 +107,7 @@ export const useAsyncRouteStore = defineStore({
       } else {
         try {
           //过滤账户是否拥有某一个权限，并将菜单从加载列表移除
-          accessedRouters = filter([...asyncRoutes, ...constantRouter], routeFilter);
+          accessedRouters = filter(asyncRoutes, routeFilter);
         } catch (error) {
           console.log(error);
         }


### PR DESCRIPTION
1、constantRouter在useAsyncRouteStore.setRouters中被concat重复添加一次。constantRouter作为无需权限验证普通路由，在动态加载路由时，没有必要和获取到路由列表合并一次并进行按权限过滤；
2、BACK权限模式下，generatorDynamicRouter的router.addRoute和router-guard中的addRoute重复，删除后让不同权限模式均只是在router-guard添加一次；