### PR TITLE
修复  clickMenuItem 事件在子组件 emits 中未定义而引起警告的问题

### DIFF
--- a/src/layout/components/Menu/index.vue
+++ b/src/layout/components/Menu/index.vue
@@ -41,7 +41,7 @@
         default: 'left',
       },
     },
-    emits: ['update:collapsed'],
+    emits: ['update:collapsed', 'clickMenuItem'],
     setup(props, { emit }) {
       // 当前路由
       const currentRoute = useRoute();


### PR DESCRIPTION
<AsideMenu @clickMenuItem="collapsed = false" />
Vue 3要求组件定义中有一个 emits 选项。例如，AsideMenu 组件它发出一个 clickMenuItem 事件，那么在该子组件的定义中，应该有这样的东西
emits: [‘clickMenuItem’]