### PR TITLE
fix: 修复ts类型找不到错误

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,7 +26,3 @@ declare interface ComponentElRef<T extends HTMLElement = HTMLDivElement> {
 declare type ComponentRef<T extends HTMLElement = HTMLDivElement> = ComponentElRef<T> | null;
 
 declare type ElRef<T extends HTMLElement = HTMLDivElement> = Nullable<T>;
-
-export type DynamicProps<T> = {
-  [P in keyof T]: Ref<T[P]> | T[P] | ComputedRef<T[P]>;
-};


### PR DESCRIPTION
这里export跟declare混用会导致
<img width="454" alt="CleanShot 2022-05-30 at 22 07 37@2x" src="https://user-images.githubusercontent.com/35173639/171009812-97c4d908-44de-400c-931a-47bc78695383.png">
而且类型DynamicProps在/types/utils.d.ts已经定义了