### PR TITLE
fix: 修复错误的 URL 正则表达式

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -211,5 +211,5 @@ export function lighten(color: string, amount: number) {
  * 判断是否 url
  * */
 export function isUrl(url: string) {
-  return /(^http|https:\/\/)/g.test(url);
+  return /^(http|https):\/\//g.test(url);
 }


### PR DESCRIPTION
这个括号加错位置了吧。
```js
 /(^http|https:\/\/)/g.test('httphello') // true
```