### PR TITLE
feat: 增加主动销毁echarts实例方法

### DIFF
--- a/src/hooks/web/useECharts.ts
+++ b/src/hooks/web/useECharts.ts
@@ -97,12 +97,7 @@ export function useECharts(
     }
   );
 
-  tryOnUnmounted(() => {
-    if (!chartInstance) return;
-    removeResizeFn();
-    chartInstance.dispose();
-    chartInstance = null;
-  });
+  tryOnUnmounted(disposeInstance);
 
   function getInstance(): echarts.ECharts | null {
     if (!chartInstance) {
@@ -111,10 +106,18 @@ export function useECharts(
     return chartInstance;
   }
 
+  function disposeInstance(){
+    if (!chartInstance) return;
+    removeResizeFn();
+    chartInstance.dispose();
+    chartInstance = null;
+  }
+
   return {
     setOptions,
     resize,
     echarts,
     getInstance,
+    disposeInstance
   };
 }


### PR DESCRIPTION
使用naive组件库时，在model中使用echarts图标，弹窗关闭时，但是弹窗组件并没有销毁，所以不会触发useECharts中的tryOnUnmounted回调，所以需要手动销毁echarts实例