### PR TITLE
fix: tabs-view 宽度计算错误

### DIFF
--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="tabs-view"
+    class="tabs-view box-border"
     :class="{
       'tabs-view-fix': multiTabsSetting.fixed,
       'tabs-view-fixed-header': isMultiHeaderFixed,
@@ -642,7 +642,6 @@
       background: var(--color);
       border-radius: 2px;
       cursor: pointer;
-      //margin-right: 10px;
 
       &-btn {
         color: var(--color);
@@ -665,7 +664,7 @@
   .tabs-view-fix {
     position: fixed;
     z-index: 5;
-    padding: 6px 19px 6px 10px;
+    padding: 6px 10px 6px 10px;
     left: 200px;
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { h, unref } from 'vue';
-import type { App, Plugin } from 'vue';
+import type { App, Plugin, Component } from 'vue';
 import { NIcon, NTag } from 'naive-ui';
 import { PageEnum } from '@/enums/pageEnum';
 import { isObject } from './is/index';
@@ -144,7 +144,7 @@ export function filterRouter(routerMap: Array<any>) {
   });
 }
 
-export const withInstall = <T>(component: T, alias?: string) => {
+export const withInstall = <T extends Component>(component: T, alias?: string) => {
   const comp = component as any;
   comp.install = (app: App) => {
     app.component(comp.name || comp.displayName, component);
@@ -187,7 +187,7 @@ export function getTreeAll(data: any[]): any[] {
 }
 
 // dynamic use hook props
-export function getDynamicProps<T, U>(props: T): Partial<U> {
+export function getDynamicProps<T extends {}, U>(props: T): Partial<U> {
   const ret: Recordable = {};
 
   Object.keys(props).map((key) => {


### PR DESCRIPTION
tabs-view 计算宽度时, 没有考虑padding, 使结果超长.

进而导致右侧的Dropdown挤占个空间, 出现两个垂直滚动条和一个水平滚动条