### PR TITLE
解决 eslint 版本升级导致所有 index.vue 会报错的问题

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = defineConfig({
   ],
   rules: {
     'vue/script-setup-uses-vars': 'error',
+    'vue/multi-word-component-names': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',


### PR DESCRIPTION
发现报错 Component name “index” should always be multi-word（组件名称 index 应有多个字组成),要求驼峰命名的格式，改成驼峰结构后报错消失
@8版本中新增了不少的规则，第一条就是 **‘vue/multi-word-component-names’: ‘error’,** 所有 index.vue 会报错。
解决方法：
按照规则 使用驼峰命名 AppHeader.vue

如果你不习惯如此，在 `.eslintrc.js` 文件中将其屏蔽掉

'vue/multi-word-component-names': 'off'