### PR TITLE
feat: ImportMeta中globEager已废弃，改为glob('*', { eager: true })

### DIFF
--- a/mock/_createProductionServer.ts
+++ b/mock/_createProductionServer.ts
@@ -1,6 +1,6 @@
 import { createProdMockServer } from 'vite-plugin-mock/es/createProdMockServer';
 
-const modules = import.meta.globEager('./**/*.ts');
+const modules = import.meta.glob('./**/*.ts', { eager: true });
 
 const mockModules: any[] = [];
 Object.keys(modules).forEach((key) => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,7 +4,7 @@ import { RedirectRoute } from '@/router/base';
 import { PageEnum } from '@/enums/pageEnum';
 import { createRouterGuards } from './router-guards';
 
-const modules = import.meta.globEager('./modules/**/*.ts');
+const modules = import.meta.glob('./modules/**/*.ts', { eager: true });
 
 const routeModuleList: RouteRecordRaw[] = [];
 

--- a/src/store/modules/index.ts
+++ b/src/store/modules/index.ts
@@ -1,4 +1,4 @@
-const allModules = import.meta.globEager('./*/index.ts');
+const allModules = import.meta.glob('./*/index.ts', { eager: true });
 const modules = {} as any;
 Object.keys(allModules).forEach((path) => {
   const fileName = path.split('/')[1];


### PR DESCRIPTION
ImportMeta中globEager已弃用，改为`import.meta.glob('*', { eager: true })`