### PR TITLE
fix: projectSetting内getters getCrumbsSetting返回对象错误

### DIFF
--- a/src/store/modules/projectSetting.ts
+++ b/src/store/modules/projectSetting.ts
@@ -69,7 +69,7 @@ export const useProjectSettingStore = defineStore({
       return this.multiTabsSetting;
     },
     getCrumbsSetting(): object {
-      return this.multiTabsSetting;
+      return this.crumbsSetting;
     },
     getPermissionMode(): string {
       return this.permissionMode;


### PR DESCRIPTION
修复pinia projectSetting内getters的getCrumbsSetting返回对象错误