### PR TITLE
style: 加宽基础表单,分步表单和上传图片中label的宽度

### DIFF
--- a/src/views/comp/upload/index.vue
+++ b/src/views/comp/upload/index.vue
@@ -7,7 +7,7 @@
       <n-grid cols="2 s:1 m:3 l:3 xl:3 2xl:3" responsive="screen">
         <n-grid-item offset="0 s:0 m:1 l:1 xl:1 2xl:1">
           <n-form
-            :label-width="80"
+            :label-width="90"
             :model="formValue"
             :rules="rules"
             label-placement="left"

--- a/src/views/form/basicForm/index.vue
+++ b/src/views/form/basicForm/index.vue
@@ -9,7 +9,7 @@
       <n-grid cols="1 s:1 m:3 l:3 xl:3 2xl:3" responsive="screen">
         <n-grid-item offset="0 s:0 m:1 l:1 xl:1 2xl:1">
           <n-form
-            :label-width="80"
+            :label-width="90"
             :model="formValue"
             :rules="rules"
             label-placement="left"

--- a/src/views/form/stepForm/Step1.vue
+++ b/src/views/form/stepForm/Step1.vue
@@ -1,6 +1,6 @@
 <template>
   <n-form
-    :label-width="90"
+    :label-width="100"
     :model="formValue"
     :rules="rules"
     label-placement="left"


### PR DESCRIPTION
加宽label用来避免label换行
修改前:
![image](https://github.com/jekip/naive-ui-admin/assets/110522314/bcc57219-900f-418d-8187-658a5ec19bdb)
![image](https://github.com/jekip/naive-ui-admin/assets/110522314/e7a52c2e-67cd-432e-a30e-3859eb71921d)
![image](https://github.com/jekip/naive-ui-admin/assets/110522314/d8ece2a8-601e-46d9-97b7-5d6ccf374c07)
修改后:
![image](https://github.com/jekip/naive-ui-admin/assets/110522314/b2fea287-2f3f-42f1-aa45-65a492115078)
![image](https://github.com/jekip/naive-ui-admin/assets/110522314/78431f29-9a7f-4b21-9ba5-f700b22ebd0e)
![image](https://github.com/jekip/naive-ui-admin/assets/110522314/c3f9a34c-f8a3-41db-a14c-3d5b717b0e3a)
